### PR TITLE
Make assetPath configurable, fix saved-locale parsing, update docs and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ assets/lang/ar.json
 assets/lang/tr.json
 ```
 
+`AnasLocalization` reads from `assets/lang` by default. If your files are in a different folder, set `assetPath` in `AnasLocalization`.
+
 2. **Generate the Dictionary class**:
 
 ```bash
@@ -64,6 +66,7 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return AnasLocalization(
       fallbackLocale: const Locale('en'),
+      assetPath: 'assets/lang', // optional if you use a custom path
       assetLocales: const [
         Locale('ar'),
         Locale('en'),
@@ -228,6 +231,7 @@ class MyApp extends StatelessWidget {
     return AnasLocalization(
       // Built-in state management handles everything automatically
       fallbackLocale: const Locale('en'),
+      assetPath: 'assets/lang', // optional if you use a custom path
       assetLocales: const [Locale('ar'), Locale('en'), Locale('tr')],
       dictionaryFactory: (map, {required locale}) => Dictionary.fromMap(map, locale: locale),
       app: MaterialApp(
@@ -346,6 +350,7 @@ class MyApp extends StatelessWidget {
     return AnasLocalizationWithSetup(
       // Setup overlay is enabled by default
       fallbackLocale: const Locale('en'),
+      assetPath: 'assets/lang', // optional if you use a custom path
       assetPath: 'assets/localization',
       assetLocales: const [
         Locale('ar'),
@@ -377,6 +382,7 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return AnasLocalization(
       fallbackLocale: const Locale('en'),
+      assetPath: 'assets/lang', // optional if you use a custom path
       assetLocales: const [
         Locale('ar'),
         Locale('en'),
@@ -500,6 +506,7 @@ class MyApp extends StatelessWidget {
     return AnasLocalization(
       // No setup overlay - direct locale changes
       fallbackLocale: const Locale('en'),
+      assetPath: 'assets/lang', // optional if you use a custom path
       assetLocales: const [Locale('ar'), Locale('en'), Locale('tr')],
       dictionaryFactory: (map, {required locale}) {
         return app_dictionary.Dictionary.fromMap(map, locale: locale);
@@ -523,6 +530,7 @@ class MyApp extends StatelessWidget {
       // Disable the setup overlay
       enableSetupScreen: false,             // 👈 Disable setup overlay
       fallbackLocale: const Locale('en'),
+      assetPath: 'assets/lang', // optional if you use a custom path
       assetLocales: const [Locale('ar'), Locale('en'), Locale('tr')],
       dictionaryFactory: (map, {required locale}) {
         return app_dictionary.Dictionary.fromMap(map, locale: locale);
@@ -548,6 +556,7 @@ class MyApp extends StatelessWidget {
       // Or disable for testing
       enableSetupScreen: !kDebugMode,       // Hide during development
       fallbackLocale: const Locale('en'),
+      assetPath: 'assets/lang', // optional if you use a custom path
       assetLocales: const [Locale('ar'), Locale('en'), Locale('tr')],
       dictionaryFactory: (map, {required locale}) {
         return app_dictionary.Dictionary.fromMap(map, locale: locale);

--- a/lib/src/anas_localization.dart
+++ b/lib/src/anas_localization.dart
@@ -12,7 +12,7 @@ import 'widgets/language_setup_overlay.dart' show AnasLanguageSetupOverlay;
 
 /*
 Instead of using import/export within the package,
-Lets use 'part' / 'part of' directives to include files.
+Let's use 'part' / 'part of' directives to include files.
 
 It will allow us to use private classes and members within the same library.
 Making usage of the package straightforward and clean.
@@ -49,7 +49,7 @@ class AnasLocalization extends StatefulWidget {
     super.key,
     required this.app,
     this.dictionaryFactory,
-    this.assetPath = 'assets/localization',
+    this.assetPath = 'assets/lang',
     this.fallbackLocale = const Locale('en'),
     this.assetLocales = const [Locale('en')],
     this.animationSetup = true, // Default to true for iPhone-style setup
@@ -73,7 +73,10 @@ class AnasLocalization extends StatefulWidget {
   final Locale fallbackLocale;
 
   /// The asset path for localization files.
-  final String assetPath; // TODO (loader-update): Make this useful
+  ///
+  /// Defaults to `assets/lang` and can be customized when app assets are placed
+  /// in a different folder.
+  final String assetPath;
 
   /// Locales exists as assets in the app
   final List<Locale> assetLocales;
@@ -132,6 +135,8 @@ class _AnasLocalizationState extends State<AnasLocalization> {
 
   /// The future of initializing locale.
   Future<void> _initialize() async {
+    LocalizationService.setAppAssetPath(widget.assetPath);
+
     // Try to auto-detect dictionary factory from LocalizationService first
     // This will be set if the generated dictionary file was imported
     final currentFactory = LocalizationService().getDictionaryFactory();

--- a/lib/src/core/localization_service.dart
+++ b/lib/src/core/localization_service.dart
@@ -60,6 +60,14 @@ class LocalizationService {
   /// The list of locale codes that this service supports. Update this list as you add new language assets.
   static List<String> supportedLocales = ['en', 'tr', 'ar'];
 
+  /// Asset directory used for app-provided localization files.
+  static String _appAssetPath = 'assets/lang';
+
+  /// Allows apps to override where localization JSON files are loaded from.
+  static void setAppAssetPath(String path) {
+    _appAssetPath = path.trim().isEmpty ? 'assets/lang' : path;
+  }
+
   /// Returns the list of all supported locale codes.
   ///
   /// This is a static getter useful for locale pickers or UI elements displaying available languages.
@@ -140,12 +148,12 @@ class LocalizationService {
   // ----- Internal helpers -----
 
   /// Attempts to load and merge JSON maps for [code] from:
-  /// 1) App assets: 'assets/lang/{code}.json' (overrides)
+  /// 1) App assets: '{configuredAssetPath}/{code}.json' (overrides)
   /// 2) Package assets: 'packages/anas_localization/assets/lang/{code}.json' (defaults)
   ///
   /// Returns the merged map if either source exists. If neither exists, throws.
   Future<Map<String, dynamic>> _loadMergedJsonFor(String code) async {
-    final appKey = 'assets/lang/$code.json';
+    final appKey = '$_appAssetPath/$code.json';
     final pkgKey = 'packages/anas_localization/assets/lang/$code.json';
 
     final Map<String, dynamic>? app = await _tryLoadJson(appKey);

--- a/lib/src/localization_manager.dart
+++ b/lib/src/localization_manager.dart
@@ -90,7 +90,17 @@ class _LocalizationManager {
   /// If no locale is saved, the [fallback] locale code (default: 'en') will be used.
   Future<Locale> loadSavedLocaleOrDefault([Locale fallback = const Locale('en')]) async {
     final saved = await AnasLocalizationStorage.loadLocale();
-    return await loadLocale(saved != null ? Locale(saved) : fallback);
+    if (saved == null || saved.trim().isEmpty) {
+      return await loadLocale(fallback);
+    }
+
+    final normalized = saved.replaceAll('-', '_');
+    final parts = normalized.split('_');
+    final resolvedLocale = parts.length > 1
+        ? Locale(parts.first, parts[1])
+        : Locale(parts.first);
+
+    return await loadLocale(resolvedLocale);
   }
 
   Future<void> saveLocale(Locale locale) async {

--- a/test/localization_service_test.dart
+++ b/test/localization_service_test.dart
@@ -57,15 +57,16 @@ void main() {
       }
     });
 
-    test('throws if both locale and fallback to English fail', () async {
-      // Simulate all assets missing by trying a totally missing locale
-      // and temporarily renaming/removing en.json for this test, or by mocking rootBundle
-      // Here, we just demonstrate structure (you'd use a mock/fake in real test)
-      // This test will always throw
-      expect(
-        () => LocalizationService().loadLocale('missing_locale'),
-        throwsException,
-      );
+    test('loadDictionaryForLocale falls back to English when locale assets are missing', () async {
+      const fakeLocale = 'zz';
+      final originalLocales = List<String>.from(LocalizationService.supportedLocales);
+      LocalizationService.supportedLocales.add(fakeLocale);
+      try {
+        final dict = await LocalizationService().loadDictionaryForLocale(fakeLocale);
+        expect(dict, isNotNull);
+      } finally {
+        LocalizationService.supportedLocales = originalLocales;
+      }
     });
 
     test('allSupportedLocales returns list of supported locales', () {


### PR DESCRIPTION
### Motivation
- Fix a docs/code mismatch where `assetPath` in `AnasLocalization` was not used and the README implied `assets/lang` is the default location. 
- Ensure apps can override where localization JSON files are loaded from and make package asset merge logic respect that.
- Correct saved-locale parsing so values like `en_US` or `en-US` produce proper `Locale(language, country)` objects instead of being treated as a single language code.
- Replace a placeholder test with a meaningful fallback test to improve coverage of the service fallback behavior.

### Description
- Changed `AnasLocalization.assetPath` default to `assets/lang`, documented it, and call `LocalizationService.setAppAssetPath(widget.assetPath)` during initialization to wire the config into the loader (`lib/src/anas_localization.dart`).
- Added `_appAssetPath` and `setAppAssetPath(...)` to `LocalizationService` and updated JSON loading to use the configured app asset directory when merging app overrides with package defaults (`lib/src/core/localization_service.dart`).
- Updated `_LocalizationManager.loadSavedLocaleOrDefault` to handle empty saved values and normalize saved locale strings with `en_US` / `en-US` formats into `Locale(language, country)` before loading (`lib/src/localization_manager.dart`).
- Updated the README to clarify the default `assets/lang` behavior and show `assetPath` usage in setup examples (`README.md`).
- Replaced a placeholder/always-throw test with a meaningful `loadDictionaryForLocale` fallback test and adjusted tests to validate fallback behavior (`test/localization_service_test.dart`).
- Fixed a small typo in the package comment (`Lets` → `Let's`).

### Testing
- Ran `git diff --check` which passed with no issues.
- Attempted to run `flutter test` and `dart test` but both CLI tools are not installed in the current environment so unit tests could not be executed here (no automated test failures reported due to missing toolchain).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981c2d73a1483298da96478dd6d31b0)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect how localization assets are discovered and how persisted locales are interpreted, which can break apps with nonstandard asset layouts or previously stored locale strings if assumptions differ.
> 
> **Overview**
> **Makes `assetPath` actually drive JSON loading** by changing the default to `assets/lang`, wiring `AnasLocalization.assetPath` into `LocalizationService` initialization, and updating merge logic to load app overrides from the configured directory.
> 
> **Fixes locale persistence parsing** by handling empty saved values and correctly converting stored strings like `en-US`/`en_US` into `Locale(language, country)` before loading.
> 
> Updates README examples to document the `assetPath` default/override, and replaces a placeholder test with a real `loadDictionaryForLocale` English-fallback test.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4b8d9ebdb97da344f7742f57a4bd35bc35b756c5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->