### PR TITLE
Strengthen workflow tests: validator edge-cases and robust codegen assertion

### DIFF
--- a/test/tool_workflow_test.dart
+++ b/test/tool_workflow_test.dart
@@ -1,35 +1,64 @@
 import 'dart:convert';
 import 'dart:io';
+
+import 'package:anas_localization/src/utils/codegen_utils.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import '../bin/validate_translations.dart';
-
-
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   group('TranslationValidator', () {
     Directory? tempDir;
+
     setUp(() {
       tempDir = Directory.systemTemp.createTempSync('i18n_test_');
     });
+
     tearDown(() {
       tempDir?.deleteSync(recursive: true);
     });
 
-    Future<File> writeJsonFile(String dir, String filename, Map<String, dynamic> data) async {
+    Future<File> writeJsonFile(
+      String dir,
+      String filename,
+      Map<String, dynamic> data,
+    ) async {
       final file = File('$dir/$filename');
       await file.create(recursive: true);
       await file.writeAsString(jsonEncode(data));
       return file;
     }
 
+    test('returns false when master file is missing', () async {
+      final validator = TranslationValidator(
+        masterFilePath: '${tempDir!.path}/en.json',
+        langDirectoryPath: tempDir!.path,
+      );
+
+      final result = await validator.validate();
+
+      expect(result, isFalse);
+    });
+
     test('succeeds when all files match master', () async {
       final master = {'hello': 'Hello', 'bye': 'Bye'};
       await writeJsonFile(tempDir!.path, 'en.json', master);
       await writeJsonFile(tempDir!.path, 'tr.json', master);
       await writeJsonFile(tempDir!.path, 'ar.json', master);
+
+      final validator = TranslationValidator(
+        masterFilePath: '${tempDir!.path}/en.json',
+        langDirectoryPath: tempDir!.path,
+      );
+      final result = await validator.validate();
+      expect(result, isTrue);
+    });
+
+    test('succeeds when only the master file exists', () async {
+      final master = {'hello': 'Hello', 'bye': 'Bye'};
+      await writeJsonFile(tempDir!.path, 'en.json', master);
 
       final validator = TranslationValidator(
         masterFilePath: '${tempDir!.path}/en.json',
@@ -69,27 +98,38 @@ void main() {
   });
 
   group('Dictionary code generation', () {
-    // This is trickier to test, because it involves running a script.
-    // A robust way is to invoke the script as a subprocess and check output file.
-    // Here is a simple structure:
-    test('generates Dictionary class file', () async {
+    test('generates Dictionary class file with field from source keys', () async {
       final tempDir = Directory.systemTemp.createTempSync('i18n_codegen_');
 
-      final codegenScript = File('bin/generate_dictionary.dart');
-      final result = await Process.run('dart', [
-        codegenScript.path,
-      ], environment: {
-        'OUTPUT_DART': '${tempDir.path}/dictionary.dart',
-      });
+      try {
+        final codegenScript = File('bin/generate_dictionary.dart');
+        final outputPath = '${tempDir.path}/dictionary.dart';
+        final result = await Process.run(
+          'dart',
+          [codegenScript.path],
+          environment: {'OUTPUT_DART': outputPath},
+        );
 
-      expect(result.exitCode, equals(0));
-      final outputFile = File('${tempDir.path}/dictionary.dart');
-      expect(outputFile.existsSync(), isTrue);
+        expect(result.exitCode, equals(0));
+        final outputFile = File(outputPath);
+        expect(outputFile.existsSync(), isTrue);
 
-      final contents = await outputFile.readAsString();
-      expect(contents, contains('class Dictionary'));
-      expect(contents, contains('final String welcome;'));
-      expect(contents, contains('factory Dictionary.fromMap'));
+        final contents = await outputFile.readAsString();
+        expect(contents, contains('class Dictionary'));
+        expect(contents, contains('factory Dictionary.fromMap'));
+
+        final enMap = jsonDecode(await File('assets/lang/en.json').readAsString())
+            as Map<String, dynamic>;
+        final sampleStringKey = enMap.entries.firstWhere((e) => e.value is String).key;
+        final expectedFieldName =
+            sanitizeDartIdentifier(snakeToCamel(sampleStringKey));
+
+        expect(contents, contains('final String $expectedFieldName;'));
+      } finally {
+        if (tempDir.existsSync()) {
+          tempDir.deleteSync(recursive: true);
+        }
+      }
     });
   });
 }


### PR DESCRIPTION
### Motivation
- Resolve a previous merge/conflict state in the workflow test and make the tests more resilient to branch variance and brittle expectations.  
- Improve confidence in the translation validator by covering edge cases (missing master file and master-only directory).  
- Remove a fragile codegen assertion that accepted multiple hardcoded field names and instead anchor the expectation to real source locale keys.  

### Description
- Added two new `TranslationValidator` unit tests: `returns false when master file is missing` and `succeeds when only the master file exists`.  
- Reworked the dictionary codegen test to invoke `bin/generate_dictionary.dart` and derive the expected generated field name from `assets/lang/en.json` using `snakeToCamel` and `sanitizeDartIdentifier` from `codegen_utils`.  
- Improved test hygiene by wrapping the codegen temp-dir usage in a `try/finally` and ensuring deterministic cleanup, and normalized the `writeJsonFile` signature to a multiline style.  
- Added the required import for `package:anas_localization/src/utils/codegen_utils.dart` and removed any merge markers so the Dart test parses cleanly.  

### Testing
- Checked for unresolved merge markers via `rg -n "^(<<<<<<<|=======|>>>>>>>)" test/tool_workflow_test.dart` which returned no matches (success).  
- Attempted `dart format --set-exit-if-changed .` but the environment lacked the `dart` CLI so formatting could not be executed here (skipped).  
- Attempted `flutter test` but the environment lacked the `flutter` CLI so tests could not be run here (skipped).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a3aa33d08832998eb51749a133283)