### PR TITLE
v1.0.1: complete validator/CLI/codegen/runtime issue set

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ You can manage and validate translation files with the package CLI:
 ```bash
 dart run anas_localization:anas_cli validate assets/lang
 dart run anas_localization:anas_cli add-key home.title "Home" assets/lang
+dart run anas_localization:anas_cli remove-key home.title assets/lang
+dart run anas_localization:anas_cli export assets/lang json translations_export.json
+dart run anas_localization:anas_cli import translations_export.json assets/lang
 dart run anas_localization:anas_cli stats assets/lang
 ```
 

--- a/lib/src/utils/translation_validator.dart
+++ b/lib/src/utils/translation_validator.dart
@@ -94,7 +94,10 @@ class TranslationValidator {
   }
 
   /// Validate all translation files in a directory
-  static Future<ValidationResult> validateTranslations(String langDirectory) async {
+  static Future<ValidationResult> validateTranslations(
+    String langDirectory, {
+    bool treatExtraKeysAsWarnings = true,
+  }) async {
     final errors = <String>[];
     final warnings = <String>[];
 
@@ -105,10 +108,7 @@ class TranslationValidator {
         return ValidationResult(isValid: false, errors: errors, warnings: warnings);
       }
 
-      final jsonFiles = dir.listSync()
-          .whereType<File>()
-          .where((f) => f.path.endsWith('.json'))
-          .toList();
+      final jsonFiles = dir.listSync().whereType<File>().where((f) => f.path.endsWith('.json')).toList();
 
       if (jsonFiles.isEmpty) {
         errors.add('No JSON translation files found in $langDirectory');
@@ -138,11 +138,10 @@ class TranslationValidator {
       final baseResult = _validateWithBase(
         translations,
         baseLocale: baseLocale,
-        treatExtraKeysAsWarnings: true,
+        treatExtraKeysAsWarnings: treatExtraKeysAsWarnings,
       );
       errors.addAll(baseResult.errors);
       warnings.addAll(baseResult.warnings);
-
     } catch (e) {
       errors.add('Validation failed: $e');
     }
@@ -239,9 +238,7 @@ class TranslationValidator {
   /// Extract placeholders from a string
   static List<String> _extractPlaceholdersFromString(String text) {
     final regex = RegExp(r'\{([a-zA-Z0-9_]+)[!?]?\}');
-    return regex.allMatches(text)
-        .map((match) => match.group(1)!)
-        .toList();
+    return regex.allMatches(text).map((match) => match.group(1)!).toList();
   }
 
   static dynamic _getValueByPath(Map<String, dynamic> map, String path) {

--- a/test/dictionary_runtime_lookup_test.dart
+++ b/test/dictionary_runtime_lookup_test.dart
@@ -1,0 +1,45 @@
+import 'package:anas_localization/anas_localization.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('Dictionary dotted runtime lookup', () {
+    late Dictionary dictionary;
+
+    setUp(() {
+      dictionary = Dictionary.fromMap(
+        {
+          'welcome': 'Welcome',
+          'home': {
+            'title': 'Home',
+            'car': {
+              'one': 'Car',
+              'other': '{count} Cars',
+            },
+          },
+        },
+        locale: 'en',
+      );
+    });
+
+    test('getString resolves dotted nested key paths', () {
+      expect(dictionary.getString('home.title'), equals('Home'));
+    });
+
+    test('getString keeps flat key behavior unchanged', () {
+      expect(dictionary.getString('welcome'), equals('Welcome'));
+    });
+
+    test('getPluralData resolves dotted nested plural maps', () {
+      final plural = dictionary.getPluralData('home.car');
+
+      expect(plural, isNotNull);
+      expect(plural!['one'], equals('Car'));
+      expect(plural['other'], equals('{count} Cars'));
+    });
+
+    test('hasKey resolves dotted nested key paths', () {
+      expect(dictionary.hasKey('home.title'), isTrue);
+      expect(dictionary.hasKey('home.missing'), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- complete remaining v1.0.1 acceptance gaps for validator behavior and strictness configurability
- add integration tests for CLI success/error paths (remove-key, export/import json/csv, non-zero failures)
- add runtime dotted-key lookup tests for Dictionary APIs
- add generator test coverage for nested string + nested plural key API generation
- update README CLI examples to include implemented commands

## Validation
- flutter test
- flutter analyze

Closes #43
Closes #44
Closes #45
Closes #46
Closes #47
Closes #48