### PR TITLE
chore(github): expand feature-impact checklist, auto-label issues for triage

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -3,6 +3,7 @@ description: Report unexpected behavior in anas_localization
 title: "fix: "
 labels:
   - type:enhancement
+  - status:needs-triage
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -3,6 +3,7 @@ description: Suggest a new capability or improvement
 title: "feat: "
 labels:
   - type:feature
+  - status:needs-triage
 body:
   - type: markdown
     attributes:
@@ -81,6 +82,14 @@ body:
       label: Likely impact
       options:
         - label: Public API change
+        - label: Breaking change (requires a major version bump)
         - label: Translation asset format change
         - label: CLI / codegen change
+        - label: Catalog UI / editor change
+        - label: Widget / runtime UI behavior change
+        - label: Migration tooling change (gen_l10n / easy_localization)
+        - label: Validator / linting rule change
+        - label: Performance or benchmark impact
+        - label: CI / release pipeline change
+        - label: Test coverage only (no behavior change)
         - label: Documentation only

--- a/.github/workflows/issue-triage-label.yml
+++ b/.github/workflows/issue-triage-label.yml
@@ -1,0 +1,25 @@
+name: Issue triage label
+
+on:
+  issues:
+    types: [opened, reopened]
+
+permissions:
+  issues: write
+
+jobs:
+  needs-triage:
+    name: Apply needs-triage label
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Add status:needs-triage
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: ['status:needs-triage'],
+            });


### PR DESCRIPTION
## Summary
- Expanded the "Likely impact" checkboxes in the feature request template with more real cases: breaking change, catalog UI, widget/runtime behavior, migration tooling, validator rules, performance/benchmark, CI/release, test-only.
- Added `status:needs-triage` as a default label on both issue templates (feature request, bug report).
- Added `.github/workflows/issue-triage-label.yml` to apply `status:needs-triage` on every issue open/reopen, regardless of whether it went through a template (covers `gh issue create`, API-created issues, blank issues).

This gives the team a lightweight "unread until reviewed" signal: every new/reopened issue starts tagged `status:needs-triage`; remove it (or swap for `status:ready`/`status:blocked`) once triaged.

## Test plan
- [ ] Open a blank issue (no template) and confirm `status:needs-triage` gets applied by the workflow
- [ ] Open an issue via the feature request / bug report templates and confirm the label is present immediately
- [ ] Reopen an existing issue and confirm the label is re-applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)