### PR TITLE
feat(github): form-label sync, stale bot, PR auto-labeler, CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,24 @@
+# Auto-requests review on PRs touching these paths.
+# Currently a single maintainer; kept path-scoped so it's ready to extend
+# as soon as additional collaborators/co-maintainers are added.
+
+# Core runtime, fallback logic, public API
+/lib/src/core/                  @Melsaeed276
+/lib/src/features/localization/ @Melsaeed276
+/lib/src/shared/                @Melsaeed276
+/lib/src/api/                   @Melsaeed276
+
+# CLI and code generation
+/bin/                           @Melsaeed276
+
+# Catalog editor (server + Flutter web app)
+/lib/src/features/catalog/      @Melsaeed276
+/tool/catalog_app/              @Melsaeed276
+
+# CI/CD and release pipeline
+/.github/workflows/             @Melsaeed276
+/.github/actions/                @Melsaeed276
+
+# Publishing metadata
+/pubspec.yaml                   @Melsaeed276
+/CHANGELOG.md                   @Melsaeed276

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,57 @@
+area:core:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'lib/src/core/**'
+          - 'lib/src/features/localization/**'
+          - 'lib/src/shared/**'
+          - 'lib/src/api/**'
+          - 'lib/src/widgets/**'
+
+area:cli:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'bin/**'
+
+area:validator:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '**/translation_validator.dart'
+          - '**/data_type_validator.dart'
+          - '**/locale_validation_service.dart'
+          - '**/locale_validation_result.dart'
+
+area:generator:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'bin/generate_dictionary.dart'
+          - '**/codegen_utils.dart'
+
+area:catalog:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'lib/src/features/catalog/**'
+          - 'tool/catalog_app/**'
+
+area:docs:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '**/*.md'
+          - 'doc/**'
+          - 'docs/**'
+          - 'mkdocs.yml'
+
+area:ci:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '.github/workflows/**'
+          - '.github/actions/**'
+
+area:examples:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'example/**'
+
+area:performance:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'benchmark/**'

--- a/.github/workflows/issue-form-labels.yml
+++ b/.github/workflows/issue-form-labels.yml
@@ -1,0 +1,55 @@
+name: Apply labels from issue form fields
+
+on:
+  issues:
+    types: [opened, edited]
+
+permissions:
+  issues: write
+
+jobs:
+  apply-labels:
+    name: Sync Area/Priority labels from form answers
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Parse dropdown answers and apply matching labels
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const KNOWN_AREAS = [
+              'area:core', 'area:validator', 'area:cli', 'area:generator',
+              'area:catalog', 'area:docs', 'area:ci', 'area:examples',
+              'area:performance',
+            ];
+            const KNOWN_PRIORITIES = ['P0', 'P1', 'P2', 'P3'];
+
+            function extractField(body, heading) {
+              const re = new RegExp(`###\\s*${heading}\\s*\\n+([^\\n#]+)`, 'i');
+              const match = (body || '').match(re);
+              return match ? match[1].trim() : null;
+            }
+
+            const issue = context.payload.issue;
+            const body = issue.body || '';
+
+            const area = extractField(body, 'Area');
+            const priority = extractField(body, 'Priority');
+
+            const toAdd = [];
+            if (area && KNOWN_AREAS.includes(area)) toAdd.push(area);
+            if (priority && KNOWN_PRIORITIES.includes(priority)) toAdd.push(priority);
+
+            if (toAdd.length === 0) {
+              core.info('No recognized Area/Priority form answers found; nothing to do.');
+              return;
+            }
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              labels: toAdd,
+            });
+
+            core.info(`Applied labels: ${toAdd.join(', ')}`);

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,19 @@
+name: PR area labeler
+
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          configuration-path: '.github/labeler.yml'
+          sync-labels: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,43 @@
+name: Stale issues and PRs
+
+on:
+  schedule:
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-issue-stale: 60
+          days-before-issue-close: 14
+          stale-issue-label: 'stale'
+          stale-issue-message: >
+            This issue has had no activity for 60 days and will be closed in
+            14 days if nothing changes. Remove the `stale` label or comment
+            to keep it open.
+          close-issue-message: >
+            Closing due to inactivity. Reopen (or comment) if this is still
+            relevant.
+          exempt-issue-labels: 'status:blocked,P0,pinned'
+
+          days-before-pr-stale: 30
+          days-before-pr-close: 7
+          stale-pr-label: 'stale'
+          stale-pr-message: >
+            This PR has had no activity for 30 days and will be closed in 7
+            days if nothing changes. Remove the `stale` label, push a
+            commit, or comment to keep it open.
+          close-pr-message: >
+            Closing due to inactivity. Reopen when it's ready to continue.
+          exempt-pr-labels: 'status:blocked'
+
+          remove-stale-when-updated: true
+          operations-per-run: 100


### PR DESCRIPTION
## Summary
- **`issue-form-labels.yml`** — GitHub issue forms render dropdown answers as body text, not labels. This parses the "Area"/"Priority" sections out of the issue body on open/edit and applies the matching real label (`area:cli`, `P1`, etc.). Fixes a gap: #170's priority-bump logic has nothing to bump if no priority label was ever actually applied.
- **`stale.yml`** — issues/PRs with no activity for 60/30 days get a `stale` label + warning comment, then auto-close 14/7 days later if untouched. `status:blocked` and `P0` issues, and `status:blocked` PRs, are exempt. Runs nightly via cron (`workflow_dispatch` also available for manual runs).
- **`labeler.yml` + `pr-labeler.yml`** — auto-labels PRs with the existing `area:*` taxonomy based on which paths changed (core/cli/validator/generator/catalog/docs/ci/examples/performance).
- **`CODEOWNERS`** — path-scoped ownership mapped to @Melsaeed276. Doesn't do much with a single maintainer today (GitHub won't request review from the PR author) but is ready the moment a second collaborator is added, and documents area ownership either way.

## Test plan
- [ ] Open an issue via a template, pick Area=`area:cli` and Priority=`P1` → confirm both labels get applied automatically
- [ ] Manually add the `stale` label / trigger `workflow_dispatch` on `stale.yml` → confirm dry-run behavior looks right before letting the cron run for real
- [ ] Open a PR touching only `bin/` → confirm it gets auto-labeled `area:cli`
- [ ] Open a PR touching `lib/src/core/` → confirm `area:core` is applied, and CODEOWNERS shows `@Melsaeed276` as a suggested reviewer on the PR page

🤖 Generated with [Claude Code](https://claude.com/claude-code)