### PR TITLE
fix(ci): pin release-please to v1.2.0 and auto-clear after release

### DIFF
--- a/.github/workflows/release-after-merge.yml
+++ b/.github/workflows/release-after-merge.yml
@@ -1,0 +1,59 @@
+name: Release After Merge
+
+# After a Release Please release PR is merged, drop the temporary
+# "last-release-sha" pin so future runs track normally from the new release.
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: read
+
+concurrency:
+  group: release-after-merge
+  cancel-in-progress: false
+
+jobs:
+  clear-last-release-sha:
+    name: Clear last-release-sha pin
+    if: >-
+      github.event.pull_request.merged == true &&
+      (startsWith(github.event.pull_request.title, 'chore(main): release') ||
+       startsWith(github.event.pull_request.title, 'release-please'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          ref: main
+          token: ${{ github.token }}
+
+      - name: Remove last-release-sha from release-please-config.json
+        shell: bash
+        run: |
+          set -euo pipefail
+          CONFIG="release-please-config.json"
+          if ! grep -q 'last-release-sha' "${CONFIG}"; then
+            echo "No last-release-sha pin present; nothing to do."
+            exit 0
+          fi
+
+          # Remove the "last-release-sha": "..." line (and trailing comma cleanup).
+          jq 'del(.["last-release-sha"])' "${CONFIG}" > "${CONFIG}.tmp"
+          mv "${CONFIG}.tmp" "${CONFIG}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add "${CONFIG}"
+          if git diff --cached --quiet; then
+            echo "Config unchanged; skipping commit."
+            exit 0
+          fi
+          git commit -m "chore(ci): clear last-release-sha pin after release"
+          git push

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -30,14 +30,21 @@ jobs:
           target-branch: main
           release-type: dart
 
+      - name: Checkout repository
+        if: ${{ steps.release-please.outputs.pr != '' }}
+        uses: actions/checkout@v7
+
       - name: Inject publish opt-in checkbox into release PR
         if: ${{ steps.release-please.outputs.pr != '' }}
         env:
           GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ steps.release-please.outputs.pr }}
+          PR_PAYLOAD: ${{ steps.release-please.outputs.pr }}
         shell: bash
         run: |
           set -euo pipefail
+          PR_NUMBER="$(printf '%s' "${PR_PAYLOAD}" | jq -r '.number')"
+          echo "Release PR number: ${PR_NUMBER}"
+
           MARKER="<!-- publish-opt-in -->"
           CHECKBOX="- [ ] Publish to pub.dev"
 
@@ -53,4 +60,3 @@ jobs:
           <!-- /publish-opt-in -->"
 
           gh pr edit "${PR_NUMBER}" --body "${NEW_BODY}"
-

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,4 +1,5 @@
 {
+  "last-release-sha": "66d64c3e4cf974be4ac334cac809316495b2e464",
   "packages": {
     ".": {
       "release-type": "dart",


### PR DESCRIPTION
## Summary
- Adds `last-release-sha` (v1.2.0 commit) to `release-please-config.json` so Release Please backfills version computation from `v1.2.0` instead of the stale `chore(main): release 1.4.0` PR (#188) in history — fixing the erroneous `1.5.0` release PR.
- Adds `release-after-merge.yml`: automatically removes the `last-release-sha` pin (via a commit to `main`) when a `chore(main): release` PR merges, so future runs track normally.
- (The publish-gating + PR checkbox changes from #189 are already on `main`.)

## Test plan
- [ ] After merge, next Release Please run opens a release PR at `1.2.1` (not `1.5.0`).
- [ ] Merging that release PR triggers `release-after-merge.yml` and clears the pin.

🤖 Generated with [opencode](https://opencode.ai)