### PR TITLE
fix(ci): force next release to 1.2.1 via release-as

### DIFF
--- a/.github/workflows/release-after-merge.yml
+++ b/.github/workflows/release-after-merge.yml
@@ -39,13 +39,13 @@ jobs:
         run: |
           set -euo pipefail
           CONFIG="release-please-config.json"
-          if ! grep -q 'last-release-sha' "${CONFIG}"; then
-            echo "No last-release-sha pin present; nothing to do."
+          if ! grep -qE 'last-release-sha|release-as' "${CONFIG}"; then
+            echo "No version pin present; nothing to do."
             exit 0
           fi
 
-          # Remove the "last-release-sha": "..." line (and trailing comma cleanup).
-          jq 'del(.["last-release-sha"])' "${CONFIG}" > "${CONFIG}.tmp"
+          # Remove temporary version pins so future runs track normally.
+          jq 'del(.["last-release-sha"], .["release-as"])' "${CONFIG}" > "${CONFIG}.tmp"
           mv "${CONFIG}.tmp" "${CONFIG}"
 
           git config user.name "github-actions[bot]"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,5 @@
 {
-  "last-release-sha": "66d64c3e4cf974be4ac334cac809316495b2e464",
+  "release-as": "1.2.1",
   "packages": {
     ".": {
       "release-type": "dart",


### PR DESCRIPTION
## Summary
- Replaces the ineffective `last-release-sha` pin with `"release-as": "1.2.1"` in `release-please-config.json`. Release Please was still reading the old merged `chore(main): release 1.4.0` PR (#188) as the version baseline and producing `1.5.0`. `release-as` manually overrides the next version regardless of history.
- Updates `release-after-merge.yml` to also strip `release-as` (not just `last-release-sha`) after the release PR merges, so subsequent runs track normally.

## Test plan
- [ ] After merge, next Release Please run opens a release PR at `1.2.1`.
- [ ] Merging that release PR triggers `release-after-merge.yml` and clears the pin.

🤖 Generated with [opencode](https://opencode.ai)