### PR TITLE
chore(release): 1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.2.1](https://github.com/Melsaeed276/anas_localization/compare/v1.2.0...v1.2.1) (2026-07-17)
+
+### Bug Fixes
+
+* **ci:** reset release version baseline to 1.2.x after mis-bumped 1.4.0/1.5.0 releases ([#195](https://github.com/Melsaeed276/anas_localization/issues/195))
+
 ## [1.2.0](https://github.com/Melsaeed276/anas_localization/compare/v1.1.0...v1.2.0) (2026-07-17)
 
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: anas_localization
 description: >-
   Flutter/Dart localization with multiple language support, runtime switching,
   custom dictionaries, code generation, and RTL for scalable internationalization.
-version: 1.2.0
+version: 1.2.1
 homepage: https://github.com/Melsaeed276/anas_localization
 
 repository: https://github.com/Melsaeed276/anas_localization


### PR DESCRIPTION
## Summary
- Bumps pubspec to 1.2.1 and adds the CHANGELOG entry.
- This manual release resets the Release Please baseline to 1.2.x (the earlier 1.4.0/1.5.0 releases were mis-computed from a stale merged release PR). Once v1.2.1 is published to pub.dev, Release Please will use it as the latest release and future auto-releases continue from 1.2.x.

## Test plan
- [ ] Merge, then tag v1.2.1 and push → release-tags.yml publishes to pub.dev.
- [ ] Next Release Please run opens a release PR at 1.2.2 (not 1.5.0).

🤖 Generated with [opencode](https://opencode.ai)